### PR TITLE
Implement BenchmarkExecutionResult.toString()

### DIFF
--- a/benchto-driver/src/main/java/com/teradata/benchto/driver/Measurable.java
+++ b/benchto-driver/src/main/java/com/teradata/benchto/driver/Measurable.java
@@ -48,10 +48,7 @@ public abstract class Measurable
     public abstract boolean isSuccessful();
 
     @Override
-    public String toString()
-    {
-        throw new UnsupportedOperationException("Expected to be implemented by inheriting class");
-    }
+    public abstract String toString();
 
     public static abstract class MeasuredBuilder<T extends Measurable, B extends MeasuredBuilder>
     {

--- a/benchto-driver/src/main/java/com/teradata/benchto/driver/execution/BenchmarkExecutionResult.java
+++ b/benchto-driver/src/main/java/com/teradata/benchto/driver/execution/BenchmarkExecutionResult.java
@@ -13,6 +13,7 @@
  */
 package com.teradata.benchto.driver.execution;
 
+import com.google.common.base.MoreObjects;
 import com.teradata.benchto.driver.Benchmark;
 import com.teradata.benchto.driver.Measurable;
 
@@ -66,6 +67,16 @@ public class BenchmarkExecutionResult
                 .collect(toList());
         failure.ifPresent(failureCauses::add);
         return failureCauses;
+    }
+
+    @Override
+    public String toString()
+    {
+        return MoreObjects.toStringHelper(this)
+                .add("benchmark", benchmark.getName())
+                .add("successful", isSuccessful())
+                .add("duration", getQueryDuration().toMillis() + " ms")
+                .toString();
     }
 
     public static class BenchmarkExecutionResultBuilder


### PR DESCRIPTION
`toString()` is useful e.g. when debugging