### PR TITLE
Give time for TaskExecutor to run callbacks

### DIFF
--- a/benchto-driver/src/main/java/com/teradata/benchto/driver/DriverApp.java
+++ b/benchto-driver/src/main/java/com/teradata/benchto/driver/DriverApp.java
@@ -42,6 +42,7 @@ import org.springframework.web.client.RestTemplate;
 import java.io.IOException;
 
 import static com.google.common.base.Preconditions.checkState;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 @Configuration
 @EnableRetry
@@ -74,6 +75,7 @@ public class DriverApp
 
         try {
             executionDriver.execute();
+            SECONDS.sleep(10); // Give time for TaskExecutor to run callbacks
             System.exit(0);
         }
         catch (Throwable e) {


### PR DESCRIPTION
Listeners are asynchronous and they are executed in `TaskExecutor`.
However, a listener can utilize some other pool (or even `TaskExecutor`)
for its job. If we initiate Spring context shutdown before listeners are
executed, they will not be able to use `TaskExecutor` or any other
thread pool bean.