### PR TITLE
Require variable matching to match fully

### DIFF
--- a/benchto-driver/src/main/java/com/teradata/benchto/driver/loader/BenchmarkByActiveVariablesFilter.java
+++ b/benchto-driver/src/main/java/com/teradata/benchto/driver/loader/BenchmarkByActiveVariablesFilter.java
@@ -53,7 +53,7 @@ class BenchmarkByActiveVariablesFilter
             if (benchmarkVariables.containsKey(variableKey)) {
                 Pattern valuePattern = variablePatterns.get(variableKey);
                 String benchmarkVariableValue = benchmarkVariables.get(variableKey);
-                if (!valuePattern.matcher(benchmarkVariableValue).find()) {
+                if (!valuePattern.matcher(benchmarkVariableValue).matches()) {
                     LOGGER.debug("Benchmark '{}' is EXCLUDED because mismatches on variable '{}', have '{}' does not match to '{}'",
                             benchmark.getName(), variableKey, valuePattern, benchmarkVariableValue);
                     return false;

--- a/benchto-driver/src/test/java/com/teradata/benchto/driver/loader/BenchmarkByActiveVariablesFilterTest.java
+++ b/benchto-driver/src/test/java/com/teradata/benchto/driver/loader/BenchmarkByActiveVariablesFilterTest.java
@@ -32,7 +32,7 @@ public class BenchmarkByActiveVariablesFilterTest
         assertThat(filter.test(benchmarkWithVariable("ala", "pies"))).isFalse();
         assertThat(filter.test(benchmarkWithVariable("ala", "kot"))).isTrue();
         assertThat(filter.test(benchmarkWithVariable("ala", "kat"))).isTrue();
-        assertThat(filter.test(benchmarkWithVariable("ala", "katar"))).isTrue();
+        assertThat(filter.test(benchmarkWithVariable("ala", "katar"))).isFalse();
         assertThat(filter.test(benchmarkWithVariable("tola", "kot"))).isFalse();
         assertThat(filter.test(benchmarkWithVariable("tola", "pies"))).isFalse();
     }

--- a/benchto-driver/src/test/java/com/teradata/benchto/driver/loader/BenchmarkLoaderTest.java
+++ b/benchto-driver/src/test/java/com/teradata/benchto/driver/loader/BenchmarkLoaderTest.java
@@ -212,7 +212,7 @@ public class BenchmarkLoaderTest
     @Test
     public void getAllBenchmarks_activeVariables_with_regex()
     {
-        withActiveVariables("format=(rc)|(tx)");
+        withActiveVariables("format=(.rc)|(tx.)");
 
         assertLoadedBenchmarksCount(4).forEach(benchmark ->
                         assertThat(benchmark.getVariables().get("format")).isIn("orc", "txt")


### PR DESCRIPTION
While partial matching is nice, it's not quite natural. Also, it's very
easy to do partial matching with full matching (enough to wrap a pattern
within `.*`), showing the intent clearly.