### PR TITLE
Fill start, end time when reporting failed query execution

### DIFF
--- a/benchto-driver/src/main/java/com/teradata/benchto/driver/execution/BenchmarkExecutionDriver.java
+++ b/benchto-driver/src/main/java/com/teradata/benchto/driver/execution/BenchmarkExecutionDriver.java
@@ -167,12 +167,15 @@ public class BenchmarkExecutionDriver
                         if (reportStatus) {
                             statusReporter.reportExecutionStarted(queryExecution);
                         }
+                        QueryExecutionResultBuilder failureResult = new QueryExecutionResultBuilder(queryExecution)
+                                .startTimer();
                         try {
                             result = queryExecutionDriver.execute(queryExecution, connection);
                         }
                         catch (Exception e) {
                             LOG.error("Query Execution failed for benchmark {}", benchmark.getName());
-                            result = new QueryExecutionResultBuilder(queryExecution)
+                            result = failureResult
+                                    .endTimer()
                                     .failed(e)
                                     .build();
                         }


### PR DESCRIPTION
The result reporting code was failing with NullPointerException when
end time was missing.