### PR TITLE
Exposed benchmark-service url and presto url to be overridden

### DIFF
--- a/benchto-driver/src/main/java/com/teradata/benchto/driver/BenchmarkProperties.java
+++ b/benchto-driver/src/main/java/com/teradata/benchto/driver/BenchmarkProperties.java
@@ -43,6 +43,12 @@ public class BenchmarkProperties
     @Value("${benchmarks}")
     private String benchmarksDirs;
 
+    @Value("${presto.url}")
+    private String prestoURL;
+
+    @Value("${benchmark-service.url}")
+    private String serviceUrl;
+
     @Value("${overrides:#{null}}")
     private String overridesPath;
 
@@ -93,6 +99,14 @@ public class BenchmarkProperties
     public List<Path> benchmarksFilesDirs()
     {
         return extractPaths(benchmarksDirs);
+    }
+
+    public String getServiceURL(){
+        return serviceUrl;
+    }
+
+    public String getPrestoURL(){
+        return prestoURL;
     }
 
     public Optional<Path> getOverridesPath()

--- a/benchto-driver/src/main/java/com/teradata/benchto/driver/DriverApp.java
+++ b/benchto-driver/src/main/java/com/teradata/benchto/driver/DriverApp.java
@@ -122,6 +122,7 @@ public class DriverApp
         addOption(options, "profile", "PROFILE", "configuration profile", "none");
         addOption(options, "profiles.directory", "PROFILES_DIRECTORY", "configuration profiles directory", "none");
         addOption(options, "frequencyCheckEnabled", "boolean", "if set no fresh benchmark will be executed", "true");
+        addOption(options, "benchmark-service.url", "String", "URL of Benchto Service", "http://localhost:8080");
         options.addOption("h", "help", false, "Display help message.");
         return options;
     }

--- a/benchto-driver/src/main/java/com/teradata/benchto/driver/presto/PrestoClient.java
+++ b/benchto-driver/src/main/java/com/teradata/benchto/driver/presto/PrestoClient.java
@@ -15,6 +15,7 @@ package com.teradata.benchto.driver.presto;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.google.common.collect.ImmutableMap;
+import com.teradata.benchto.driver.BenchmarkProperties;
 import com.teradata.benchto.driver.service.Measurement;
 import com.teradata.benchto.driver.utils.UnitConverter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,11 +58,11 @@ public class PrestoClient
             .put("peakMemoryReservation", BYTE)
             .build();
 
-    @Value("${presto.url}")
-    private String prestoURL;
-
     @Autowired
     private RestTemplate restTemplate;
+
+    @Autowired
+    private BenchmarkProperties properties;
 
     @Retryable(value = RestClientException.class, backoff = @Backoff(1000))
     public List<Measurement> loadMetrics(String queryId)
@@ -84,10 +85,10 @@ public class PrestoClient
 
     private URI buildQueryInfoURI(String queryId)
     {
-        checkState(!prestoURL.isEmpty());
+        checkState(!properties.getPrestoURL().isEmpty());
 
         UriComponentsBuilder uriBuilder = UriComponentsBuilder
-                .fromUriString(prestoURL)
+                .fromUriString(properties.getPrestoURL())
                 .pathSegment("v1", "query", queryId);
 
         return URI.create(uriBuilder.toUriString());


### PR DESCRIPTION
I started working with benchto recently and needed to automate the benchmarking. With this I needed to be able to change the `benchmark-service.url` and `presto.url` without having to repackage the jar file. Using the profile and profile directory parameters I can manipulate some of the variables needed, but I was not able to change the benchto-service url. 

This PR essentially just allows a profile .properties file to change the benchmark service url and the presto url. Feel free to completely reject this PR if it turns out I've just read the documentation wrong and can already override these variables without having to run `mvn package`. 