### PR TITLE
Force wait for health check

### DIFF
--- a/benchto-driver/pom.xml
+++ b/benchto-driver/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.teradata.benchto</groupId>
         <artifactId>benchto-base</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>benchto-driver</artifactId>

--- a/benchto-driver/src/main/java/com/teradata/benchto/driver/macro/query/QueryMacroExecutionDriver.java
+++ b/benchto-driver/src/main/java/com/teradata/benchto/driver/macro/query/QueryMacroExecutionDriver.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Component;
 import javax.sql.DataSource;
 
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
@@ -99,7 +100,13 @@ public class QueryMacroExecutionDriver
             }
             else {
                 try (Statement statement = connection.createStatement()) {
-                    statement.execute(sqlStatement);
+                    if (statement.execute(sqlStatement)) {
+                        try (ResultSet resultSet = statement.getResultSet()) {
+                            while (resultSet.next()) {
+                                // ignore rows
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/benchto-generator/pom.xml
+++ b/benchto-generator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.teradata.benchto</groupId>
         <artifactId>benchto-base</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>benchto-generator</artifactId>

--- a/benchto-service/pom.xml
+++ b/benchto-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.teradata.benchto</groupId>
         <artifactId>benchto-base</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>benchto-service</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.teradata.benchto</groupId>
     <artifactId>benchto-base</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>benchto-base</name>
 


### PR DESCRIPTION
Health check query execution driver was not waiting for the query to finish. This patch forces it to wait for all results before returning.

This is related to #51 but I couldn't confirm that it solves the problem completely. Will be still working on it.