### PR TITLE
Adding throughput test to benchto

### DIFF
--- a/benchto-driver/src/main/java/io/prestodb/benchto/driver/Benchmark.java
+++ b/benchto-driver/src/main/java/io/prestodb/benchto/driver/Benchmark.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -44,6 +45,7 @@ public class Benchmark
     private Map<String, String> variables;
     private String uniqueName;
     private Optional<Duration> frequency;
+    private boolean throughputTest;
 
     private Benchmark()
     {
@@ -147,6 +149,11 @@ public class Benchmark
         return frequency;
     }
 
+    public boolean isThroughputTest()
+    {
+        return throughputTest;
+    }
+
     @Override
     public String toString()
     {
@@ -156,10 +163,13 @@ public class Benchmark
                 .add("sequenceId", sequenceId)
                 .add("dataSource", dataSource)
                 .add("environment", environment)
-                .add("queries", queries)
+                .add("queries", queries.stream()
+                        .map(Query::getName)
+                        .collect(Collectors.joining(", ")))
                 .add("runs", runs)
                 .add("prewarmRuns", prewarmRuns)
                 .add("concurrency", concurrency)
+                .add("throughputTest", throughputTest)
                 .add("frequency", frequency)
                 .add("beforeBenchmarkMacros", beforeBenchmarkMacros)
                 .add("afterBenchmarkMacros", afterBenchmarkMacros)
@@ -192,7 +202,8 @@ public class Benchmark
                 Objects.equal(beforeExecutionMacros, benchmark.beforeExecutionMacros) &&
                 Objects.equal(afterExecutionMacros, benchmark.afterExecutionMacros) &&
                 Objects.equal(variables, benchmark.variables) &&
-                Objects.equal(frequency, benchmark.frequency);
+                Objects.equal(frequency, benchmark.frequency) &&
+                Objects.equal(throughputTest, benchmark.throughputTest);
     }
 
     @Override
@@ -211,7 +222,8 @@ public class Benchmark
                 beforeExecutionMacros,
                 afterExecutionMacros,
                 variables,
-                frequency);
+                frequency,
+                throughputTest);
     }
 
     public static class BenchmarkBuilder
@@ -290,6 +302,12 @@ public class Benchmark
         public BenchmarkBuilder withFrequency(Optional<Duration> frequency)
         {
             this.benchmark.frequency = frequency;
+            return this;
+        }
+
+        public BenchmarkBuilder withThroughputTest(boolean throughputTest)
+        {
+            this.benchmark.throughputTest = throughputTest;
             return this;
         }
 

--- a/benchto-driver/src/main/java/io/prestodb/benchto/driver/execution/BenchmarkExecutionDriver.java
+++ b/benchto-driver/src/main/java/io/prestodb/benchto/driver/execution/BenchmarkExecutionDriver.java
@@ -24,6 +24,7 @@ import io.prestodb.benchto.driver.execution.BenchmarkExecutionResult.BenchmarkEx
 import io.prestodb.benchto.driver.execution.QueryExecutionResult.QueryExecutionResultBuilder;
 import io.prestodb.benchto.driver.listeners.benchmark.BenchmarkStatusReporter;
 import io.prestodb.benchto.driver.macro.MacroService;
+import io.prestodb.benchto.driver.utils.PermutationUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,12 +35,17 @@ import javax.sql.DataSource;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Lists.newArrayList;
+import static io.prestodb.benchto.driver.utils.TimeUtils.nowUtc;
+import static java.lang.String.format;
 
 @Component
 public class BenchmarkExecutionDriver
@@ -64,7 +70,7 @@ public class BenchmarkExecutionDriver
     @Autowired
     private ApplicationContext applicationContext;
 
-    public BenchmarkExecutionResult execute(Benchmark benchmark, int benchmarkOrdinalNumber, int benchmarkTotalCount)
+    public BenchmarkExecutionResult execute(Benchmark benchmark, int benchmarkOrdinalNumber, int benchmarkTotalCount, Optional<ZonedDateTime> executionTimeLimit)
     {
         LOG.info("[{} of {}] processing benchmark: {}", benchmarkOrdinalNumber, benchmarkTotalCount, benchmark);
 
@@ -72,7 +78,7 @@ public class BenchmarkExecutionDriver
         try {
             macroService.runBenchmarkMacros(benchmark.getBeforeBenchmarkMacros(), benchmark);
 
-            benchmarkExecutionResult = executeBenchmark(benchmark);
+            benchmarkExecutionResult = executeBenchmark(benchmark, executionTimeLimit);
 
             macroService.runBenchmarkMacros(benchmark.getAfterBenchmarkMacros(), benchmark);
 
@@ -91,12 +97,12 @@ public class BenchmarkExecutionDriver
         }
     }
 
-    private BenchmarkExecutionResult executeBenchmark(Benchmark benchmark)
+    private BenchmarkExecutionResult executeBenchmark(Benchmark benchmark, Optional<ZonedDateTime> executionTimeLimit)
     {
         BenchmarkExecutionResultBuilder resultBuilder = new BenchmarkExecutionResultBuilder(benchmark);
         List<QueryExecutionResult> executions;
         try {
-            executeQueries(benchmark, benchmark.getPrewarmRuns(), false);
+            executeQueries(benchmark, benchmark.getPrewarmRuns(), false, executionTimeLimit);
 
             executionSynchronizer.awaitAfterBenchmarkExecutionAndBeforeResultReport(benchmark);
 
@@ -105,7 +111,7 @@ public class BenchmarkExecutionDriver
             resultBuilder = resultBuilder.startTimer();
 
             try {
-                executions = executeQueries(benchmark, benchmark.getRuns(), true);
+                executions = executeQueries(benchmark, benchmark.getRuns(), true, executionTimeLimit);
             }
             finally {
                 resultBuilder = resultBuilder.endTimer();
@@ -134,13 +140,22 @@ public class BenchmarkExecutionDriver
     }
 
     @SuppressWarnings("unchecked")
-    private List<QueryExecutionResult> executeQueries(Benchmark benchmark, int runs, boolean reportStatus)
+    private List<QueryExecutionResult> executeQueries(Benchmark benchmark, int runs, boolean reportStatus, Optional<ZonedDateTime> executionTimeLimit)
     {
         ListeningExecutorService executorService = executorServiceFactory.create(benchmark.getConcurrency());
         try {
-            List<Callable<QueryExecutionResult>> queryExecutionCallables = buildQueryExecutionCallables(benchmark, runs, reportStatus);
-            List<ListenableFuture<QueryExecutionResult>> executionFutures = (List) executorService.invokeAll(queryExecutionCallables);
-            return Futures.allAsList(executionFutures).get();
+            if (benchmark.isThroughputTest()) {
+                List<Callable<List<QueryExecutionResult>>> queryExecutionCallables = buildConcurrencyQueryExecutionCallables(benchmark, runs, reportStatus, executionTimeLimit);
+                List<ListenableFuture<List<QueryExecutionResult>>> executionFutures = (List) executorService.invokeAll(queryExecutionCallables);
+                return Futures.allAsList(executionFutures).get().stream()
+                        .flatMap(List::stream)
+                        .collect(toImmutableList());
+            }
+            else {
+                List<Callable<QueryExecutionResult>> queryExecutionCallables = buildQueryExecutionCallables(benchmark, runs, reportStatus);
+                List<ListenableFuture<QueryExecutionResult>> executionFutures = (List) executorService.invokeAll(queryExecutionCallables);
+                return Futures.allAsList(executionFutures).get();
+            }
         }
         catch (InterruptedException | ExecutionException e) {
             throw new BenchmarkExecutionException("Could not execute benchmark", e);
@@ -191,6 +206,121 @@ public class BenchmarkExecutionDriver
             }
         }
         return executionCallables;
+    }
+
+    private List<Callable<List<QueryExecutionResult>>> buildConcurrencyQueryExecutionCallables(Benchmark benchmark, int runs, boolean reportStatus, Optional<ZonedDateTime> executionTimeLimit)
+    {
+        List<Callable<List<QueryExecutionResult>>> executionCallables = newArrayList();
+        for (int thread = 0; thread < benchmark.getConcurrency(); thread++) {
+            int finalThread = thread;
+            executionCallables.add(() -> {
+                LOG.info("Running throughput test: {} queries, {} runs", benchmark.getQueries().size(), runs);
+                int[] queryOrder = PermutationUtils.preparePermutation(benchmark.getQueries().size(), finalThread);
+                List<QueryExecutionResult> queryExecutionResults = executeConcurrentQueries(benchmark, runs, reportStatus, executionTimeLimit, finalThread, queryOrder);
+                if (reportStatus) {
+                    statusReporter.reportConcurrencyTestExecutionFinished(queryExecutionResults);
+                }
+                return queryExecutionResults;
+            });
+        }
+        return executionCallables;
+    }
+
+    private List<QueryExecutionResult> executeConcurrentQueries(Benchmark benchmark, int runs, boolean reportStatus, Optional<ZonedDateTime> executionTimeLimit, int threadNumber, int[] queryOrder)
+            throws SQLException
+    {
+        boolean firstQuery = true;
+        List<QueryExecutionResult> queryExecutionResults = newArrayList();
+        try (Connection connection = getConnectionFor(new QueryExecution(benchmark, benchmark.getQueries().get(0), 0))) {
+            for (int run = 1; run <= runs; run++) {
+                for (int queryIndex = 0; queryIndex < benchmark.getQueries().size(); queryIndex++) {
+                    int permutedQueryIndex = queryIndex;
+                    if (!reportStatus) {
+                        if (queryIndex % benchmark.getConcurrency() != threadNumber) {
+                            // for pre-warming we split queries among all threads instead
+                            // of each thread running all queries
+                            continue;
+                        }
+                        LOG.info("Executing pre-warm query {}", queryIndex);
+                    }
+                    else {
+                        permutedQueryIndex = queryOrder[queryIndex];
+                    }
+                    Query query = benchmark.getQueries().get(permutedQueryIndex);
+                    QueryExecution queryExecution = new QueryExecution(
+                            benchmark,
+                            query,
+                            queryIndex
+                                    + threadNumber * benchmark.getQueries().size()
+                                    + (run - 1) * benchmark.getConcurrency() * benchmark.getQueries().size());
+                    if (firstQuery && reportStatus) {
+                        statusReporter.reportExecutionStarted(queryExecution);
+                        firstQuery = false;
+                    }
+                    try {
+                        queryExecutionResults.add(executeSingleQuery(queryExecution, benchmark, connection, false, executionTimeLimit));
+                    }
+                    catch (TimeLimitException e) {
+                        LOG.warn("Interrupting benchmark {} due to time limit exceeded", benchmark.getName());
+                        return queryExecutionResults;
+                    }
+                }
+            }
+        }
+        return queryExecutionResults;
+    }
+
+    private QueryExecutionResult executeSingleQuery(
+            QueryExecution queryExecution,
+            Benchmark benchmark,
+            Connection connection,
+            boolean reportStatus,
+            Optional<ZonedDateTime> executionTimeLimit)
+            throws TimeLimitException
+    {
+        QueryExecutionResult result;
+        macroService.runBenchmarkMacros(benchmark.getBeforeExecutionMacros(), benchmark, connection);
+        if (reportStatus) {
+            statusReporter.reportExecutionStarted(queryExecution);
+        }
+        QueryExecutionResultBuilder failureResult = new QueryExecutionResultBuilder(queryExecution)
+                .startTimer();
+        try {
+            result = queryExecutionDriver.execute(queryExecution, connection);
+        }
+        catch (Exception e) {
+            LOG.error("Query Execution failed for benchmark {} query {}", benchmark.getName(), queryExecution.getQueryName());
+            result = failureResult
+                    .endTimer()
+                    .failed(e)
+                    .build();
+        }
+        if (isTimeLimitExceeded(executionTimeLimit)) {
+            throw new TimeLimitException(benchmark, queryExecution);
+        }
+
+        if (reportStatus) {
+            statusReporter.reportExecutionFinished(result);
+        }
+        macroService.runBenchmarkMacros(benchmark.getAfterExecutionMacros(), benchmark, connection);
+        return result;
+    }
+
+    private boolean isTimeLimitExceeded(Optional<ZonedDateTime> executionTimeLimit)
+    {
+        return executionTimeLimit.map(limit -> limit.compareTo(nowUtc()) < 0).orElse(false);
+    }
+
+    static class TimeLimitException
+            extends RuntimeException
+    {
+        public TimeLimitException(Benchmark benchmark, QueryExecution queryExecution)
+        {
+            super(format(
+                    "Query execution exceeded time limit for benchmark %s query %s",
+                    benchmark.getName(),
+                    queryExecution.getQueryName()));
+        }
     }
 
     private Connection getConnectionFor(QueryExecution queryExecution)

--- a/benchto-driver/src/main/java/io/prestodb/benchto/driver/execution/ExecutionDriver.java
+++ b/benchto-driver/src/main/java/io/prestodb/benchto/driver/execution/ExecutionDriver.java
@@ -124,7 +124,7 @@ public class ExecutionDriver
             }
 
             executeHealthCheck(benchmark);
-            benchmarkExecutionResults.add(benchmarkExecutionDriver.execute(benchmark, benchmarkOrdinalNumber++, benchmarks.size()));
+            benchmarkExecutionResults.add(benchmarkExecutionDriver.execute(benchmark, benchmarkOrdinalNumber++, benchmarks.size(), getExecutionTimeLimit()));
             benchmarkStatusReporter.processCompletedFutures();
         }
 
@@ -143,6 +143,12 @@ public class ExecutionDriver
     {
         Optional<Duration> timeLimit = properties.getTimeLimit();
         return timeLimit.isPresent() && timeLimit.get().compareTo(Duration.between(startTime, nowUtc())) < 0;
+    }
+
+    private Optional<ZonedDateTime> getExecutionTimeLimit()
+    {
+        Optional<Duration> timeLimit = properties.getTimeLimit();
+        return timeLimit.map(startTime::plus);
     }
 
     private void executeHealthCheck(Benchmark benchmark)

--- a/benchto-driver/src/main/java/io/prestodb/benchto/driver/listeners/BenchmarkServiceExecutionListener.java
+++ b/benchto-driver/src/main/java/io/prestodb/benchto/driver/listeners/BenchmarkServiceExecutionListener.java
@@ -36,19 +36,25 @@ import org.springframework.stereotype.Component;
 
 import java.sql.SQLException;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 import static io.prestodb.benchto.driver.loader.BenchmarkDescriptor.RESERVED_KEYWORDS;
 import static io.prestodb.benchto.driver.service.BenchmarkServiceClient.FinishRequest.Status.ENDED;
 import static io.prestodb.benchto.driver.service.BenchmarkServiceClient.FinishRequest.Status.FAILED;
 import static io.prestodb.benchto.driver.utils.ExceptionUtils.stackTraceToString;
 import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 
 @Component
 public class BenchmarkServiceExecutionListener
@@ -158,6 +164,43 @@ public class BenchmarkServiceExecutionListener
                             executionSequenceId(executionResult.getQueryExecution()),
                             request);
                 });
+    }
+
+    @Override
+    public Future<?> concurrencyTestExecutionFinished(List<QueryExecutionResult> executions)
+    {
+        if (executions.isEmpty()) {
+            return completedFuture(emptyList());
+        }
+        return taskExecutor.submit(() -> {
+            FinishRequest finishRequest = new FinishRequestBuilder()
+                    .withStatus(ENDED)
+                    .withEndTime(
+                            executions.stream()
+                                    .map(e -> e.getUtcEnd().toInstant())
+                                    .max(Comparator.comparing(Instant::toEpochMilli))
+                                    .orElseThrow(NoSuchElementException::new))
+                    .addMeasurement(Measurement.measurement(
+                            "queries_successful",
+                            "NONE",
+                            executions.stream().filter(QueryExecutionResult::isSuccessful).count()))
+                    .addMeasurement(Measurement.measurement(
+                            "queries_failed",
+                            "NONE",
+                            executions.stream().filter(query -> !query.isSuccessful()).count()))
+                    .addAttribute(
+                            "queries_order",
+                            executions.stream()
+                                    .map(QueryExecutionResult::getQueryName)
+                                    .collect(Collectors.joining(",")))
+                    .build();
+
+            benchmarkServiceClient.finishExecution(
+                    executions.stream().findFirst().orElseThrow(NoSuchElementException::new).getBenchmark().getUniqueName(),
+                    executions.stream().findFirst().orElseThrow(NoSuchElementException::new).getBenchmark().getSequenceId(),
+                    executionSequenceId(executions.stream().findFirst().orElseThrow(NoSuchElementException::new).getQueryExecution()),
+                    finishRequest);
+        });
     }
 
     private FinishRequest buildExecutionFinishedRequest(QueryExecutionResult executionResult, List<Measurement> measurements)

--- a/benchto-driver/src/main/java/io/prestodb/benchto/driver/listeners/GraphiteEventExecutionListener.java
+++ b/benchto-driver/src/main/java/io/prestodb/benchto/driver/listeners/GraphiteEventExecutionListener.java
@@ -27,6 +27,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
@@ -115,5 +116,11 @@ public class GraphiteEventExecutionListener
         executionSynchronizer.awaitAfterQueryExecutionAndBeforeResultReport(executionResult);
 
         return future;
+    }
+
+    @Override
+    public Future<?> concurrencyTestExecutionFinished(List<QueryExecutionResult> executions)
+    {
+        return CompletableFuture.completedFuture("");
     }
 }

--- a/benchto-driver/src/main/java/io/prestodb/benchto/driver/listeners/LoggingBenchmarkExecutionListener.java
+++ b/benchto-driver/src/main/java/io/prestodb/benchto/driver/listeners/LoggingBenchmarkExecutionListener.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
@@ -73,6 +74,15 @@ public class LoggingBenchmarkExecutionListener
                     result.getBenchmark().getRuns(), result.getFailureCause().getMessage());
         }
 
+        return CompletableFuture.completedFuture("");
+    }
+
+    @Override
+    public Future<?> concurrencyTestExecutionFinished(List<QueryExecutionResult> executions)
+    {
+        LOG.info("Concurrency test queries finished, queries successful {}, queries failed {}",
+                executions.stream().filter(QueryExecutionResult::isSuccessful).count(),
+                executions.stream().filter(execution -> !execution.isSuccessful()).count());
         return CompletableFuture.completedFuture("");
     }
 }

--- a/benchto-driver/src/main/java/io/prestodb/benchto/driver/listeners/benchmark/BenchmarkExecutionListener.java
+++ b/benchto-driver/src/main/java/io/prestodb/benchto/driver/listeners/benchmark/BenchmarkExecutionListener.java
@@ -19,6 +19,7 @@ import io.prestodb.benchto.driver.execution.QueryExecution;
 import io.prestodb.benchto.driver.execution.QueryExecutionResult;
 import org.springframework.core.Ordered;
 
+import java.util.List;
 import java.util.concurrent.Future;
 
 public interface BenchmarkExecutionListener
@@ -31,4 +32,6 @@ public interface BenchmarkExecutionListener
     Future<?> executionStarted(QueryExecution queryExecution);
 
     Future<?> executionFinished(QueryExecutionResult execution);
+
+    Future<?> concurrencyTestExecutionFinished(List<QueryExecutionResult> executions);
 }

--- a/benchto-driver/src/main/java/io/prestodb/benchto/driver/listeners/benchmark/BenchmarkStatusReporter.java
+++ b/benchto-driver/src/main/java/io/prestodb/benchto/driver/listeners/benchmark/BenchmarkStatusReporter.java
@@ -48,7 +48,7 @@ public class BenchmarkStatusReporter
 
     private final List<BenchmarkExecutionListener> executionListeners;
 
-    private Queue<Future<?>> pendingFutures = synchronizedQueue(new ArrayDeque<>());
+    private final Queue<Future<?>> pendingFutures = synchronizedQueue(new ArrayDeque<>());
 
     @Autowired
     public BenchmarkStatusReporter(List<BenchmarkExecutionListener> executionListeners)
@@ -131,6 +131,11 @@ public class BenchmarkStatusReporter
     public void reportExecutionFinished(QueryExecutionResult queryExecutionResult)
     {
         fireListeners(BenchmarkExecutionListener::executionFinished, queryExecutionResult);
+    }
+
+    public void reportConcurrencyTestExecutionFinished(List<QueryExecutionResult> executionResults)
+    {
+        fireListeners(BenchmarkExecutionListener::concurrencyTestExecutionFinished, executionResults);
     }
 
     private <T> void fireListeners(BiFunction<BenchmarkExecutionListener, T, Future<?>> invoker, T argument)

--- a/benchto-driver/src/main/java/io/prestodb/benchto/driver/listeners/benchmark/DefaultBenchmarkExecutionListener.java
+++ b/benchto-driver/src/main/java/io/prestodb/benchto/driver/listeners/benchmark/DefaultBenchmarkExecutionListener.java
@@ -18,6 +18,7 @@ import io.prestodb.benchto.driver.execution.BenchmarkExecutionResult;
 import io.prestodb.benchto.driver.execution.QueryExecution;
 import io.prestodb.benchto.driver.execution.QueryExecutionResult;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
@@ -50,6 +51,12 @@ public class DefaultBenchmarkExecutionListener
 
     @Override
     public Future<?> executionFinished(QueryExecutionResult execution)
+    {
+        return CompletableFuture.completedFuture("");
+    }
+
+    @Override
+    public Future<?> concurrencyTestExecutionFinished(List<QueryExecutionResult> executions)
     {
         return CompletableFuture.completedFuture("");
     }

--- a/benchto-driver/src/main/java/io/prestodb/benchto/driver/loader/BenchmarkDescriptor.java
+++ b/benchto-driver/src/main/java/io/prestodb/benchto/driver/loader/BenchmarkDescriptor.java
@@ -39,6 +39,7 @@ public class BenchmarkDescriptor
     public static final String VARIABLES_KEY = "variables";
     public static final String QUARANTINE_KEY = "quarantine";
     public static final String FREQUENCY_KEY = "frequency";
+    public static final String THROUGHPUT_TEST_KEY = "throughput-test";
 
     public static final Set<String> RESERVED_KEYWORDS = ImmutableSet.of(
             DATA_SOURCE_KEY,
@@ -52,7 +53,8 @@ public class BenchmarkDescriptor
             AFTER_EXECUTION_MACROS_KEY,
             VARIABLES_KEY,
             QUARANTINE_KEY,
-            FREQUENCY_KEY);
+            FREQUENCY_KEY,
+            THROUGHPUT_TEST_KEY);
 
     private final Map<String, String> variables;
 
@@ -115,6 +117,11 @@ public class BenchmarkDescriptor
     public List<String> getAfterExecutionMacros()
     {
         return asStringList(variables.getOrDefault(AFTER_EXECUTION_MACROS_KEY, ""));
+    }
+
+    public boolean getThroughputTest()
+    {
+        return variables.getOrDefault(THROUGHPUT_TEST_KEY, "false").toLowerCase().equals("true");
     }
 
     private Optional<Integer> getIntegerOptional(String key)

--- a/benchto-driver/src/main/java/io/prestodb/benchto/driver/loader/BenchmarkLoader.java
+++ b/benchto-driver/src/main/java/io/prestodb/benchto/driver/loader/BenchmarkLoader.java
@@ -234,6 +234,7 @@ public class BenchmarkLoader
                         .withPrewarmRuns(benchmarkDescriptor.getPrewarmRepeats().orElse(DEFAULT_PREWARM_RUNS))
                         .withConcurrency(benchmarkDescriptor.getConcurrency().orElse(DEFAULT_CONCURRENCY))
                         .withFrequency(benchmarkDescriptor.getFrequency().map(frequency -> Duration.ofDays(frequency)))
+                        .withThroughputTest(benchmarkDescriptor.getThroughputTest())
                         .withBeforeBenchmarkMacros(benchmarkDescriptor.getBeforeBenchmarkMacros())
                         .withAfterBenchmarkMacros(benchmarkDescriptor.getAfterBenchmarkMacros())
                         .withBeforeExecutionMacros(benchmarkDescriptor.getBeforeExecutionMacros())
@@ -403,14 +404,15 @@ public class BenchmarkLoader
 
     private void printFormattedBenchmarksInfo(String formatString, Collection<Benchmark> benchmarks)
     {
-        LOGGER.info(format(formatString, "Benchmark Name", "Data Source", "Runs", "Prewarms", "Concurrency"));
+        LOGGER.info(format(formatString, "Benchmark Name", "Data Source", "Runs", "Prewarms", "Concurrency", "Throughput Test"));
         benchmarks.stream()
                 .map(benchmark -> format(formatString,
                         benchmark.getName(),
                         benchmark.getDataSource(),
                         benchmark.getRuns() + "",
                         benchmark.getPrewarmRuns() + "",
-                        benchmark.getConcurrency() + ""))
+                        benchmark.getConcurrency() + "",
+                        benchmark.isThroughputTest() + ""))
                 .distinct()
                 .forEach(LOGGER::info);
     }
@@ -420,6 +422,6 @@ public class BenchmarkLoader
         int nameMaxLength = benchmarks.stream().mapToInt((benchmark) -> benchmark.getName().length()).max().orElseGet(() -> 10);
         int dataSourceMaxLength = benchmarks.stream().mapToInt((benchmark) -> benchmark.getDataSource().length()).max().orElseGet(() -> 10);
         int indent = 3;
-        return "\t| %-" + (nameMaxLength + indent) + "s | %-" + (dataSourceMaxLength + indent) + "s | %-4s | %-8s | %-11s |";
+        return "\t| %-" + (nameMaxLength + indent) + "s | %-" + (dataSourceMaxLength + indent) + "s | %-4s | %-8s | %-11s | %-15s |";
     }
 }

--- a/benchto-driver/src/main/java/io/prestodb/benchto/driver/presto/PrestoMetricsLoader.java
+++ b/benchto-driver/src/main/java/io/prestodb/benchto/driver/presto/PrestoMetricsLoader.java
@@ -40,7 +40,7 @@ public class PrestoMetricsLoader
     {
         if (measurable instanceof QueryExecutionResult) {
             QueryExecutionResult executionResult = (QueryExecutionResult) measurable;
-            if (executionResult.getPrestoQueryId().isPresent()) {
+            if (executionResult.getPrestoQueryId().isPresent() && !executionResult.getBenchmark().isThroughputTest()) {
                 return completedFuture(prestoClient.loadMetrics(executionResult.getPrestoQueryId().get()));
             }
         }

--- a/benchto-driver/src/main/java/io/prestodb/benchto/driver/utils/PermutationUtils.java
+++ b/benchto-driver/src/main/java/io/prestodb/benchto/driver/utils/PermutationUtils.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestodb.benchto.driver.utils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.toList;
+
+public class PermutationUtils
+{
+    public static int[] preparePermutation(int size, int permutationId)
+    {
+        List<Integer> intList = IntStream
+                .range(0, size)
+                .boxed()
+                .collect(toList());
+        Collections.shuffle(intList, new Random(permutationId * 7823L));
+        return intList.stream().mapToInt(i -> i).toArray();
+    }
+
+    private PermutationUtils()
+    {
+    }
+}

--- a/benchto-driver/src/test/java/io/prestodb/benchto/driver/execution/BenchmarkExecutionDriverTest.java
+++ b/benchto-driver/src/test/java/io/prestodb/benchto/driver/execution/BenchmarkExecutionDriverTest.java
@@ -25,6 +25,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
@@ -64,7 +66,7 @@ public class BenchmarkExecutionDriverTest
     @Test
     public void successfulRun()
     {
-        BenchmarkExecutionResult benchmarkExecutionResult = driver.execute(mock(Benchmark.class), 0, 0);
+        BenchmarkExecutionResult benchmarkExecutionResult = driver.execute(mock(Benchmark.class), 0, 0, Optional.empty());
 
         assertThat(benchmarkExecutionResult.getFailureCauses()).isEmpty();
         assertThat(benchmarkExecutionResult.isSuccessful()).isTrue();
@@ -77,7 +79,7 @@ public class BenchmarkExecutionDriverTest
         doNothing().doThrow(afterMacroException)
                 .when(macroService).runBenchmarkMacros(anyList(), any(Benchmark.class));
 
-        BenchmarkExecutionResult benchmarkExecutionResult = driver.execute(mock(Benchmark.class), 0, 0);
+        BenchmarkExecutionResult benchmarkExecutionResult = driver.execute(mock(Benchmark.class), 0, 0, Optional.empty());
 
         assertThat(benchmarkExecutionResult.isSuccessful()).isFalse();
         assertThat(benchmarkExecutionResult.getFailureCauses()).containsExactly(afterMacroException);
@@ -93,7 +95,7 @@ public class BenchmarkExecutionDriverTest
         doNothing().doThrow(afterMacroException)
                 .when(macroService).runBenchmarkMacros(anyList());
 
-        BenchmarkExecutionResult benchmarkExecutionResult = driver.execute(mock(Benchmark.class), 0, 0);
+        BenchmarkExecutionResult benchmarkExecutionResult = driver.execute(mock(Benchmark.class), 0, 0, Optional.empty());
 
         assertThat(benchmarkExecutionResult.isSuccessful()).isFalse();
         assertThat(benchmarkExecutionResult.getFailureCauses()).containsExactly(executorServiceException);

--- a/benchto-driver/src/test/java/io/prestodb/benchto/driver/execution/ExecutionDriverTest.java
+++ b/benchto-driver/src/test/java/io/prestodb/benchto/driver/execution/ExecutionDriverTest.java
@@ -86,7 +86,7 @@ public class ExecutionDriverTest
                 .thenReturn(Optional.of(ImmutableList.of("health-check-macro")));
         when(benchmarkProperties.getExecutionSequenceId())
                 .thenReturn(Optional.of("sequence-id"));
-        when(benchmarkExecutionDriver.execute(any(Benchmark.class), anyInt(), anyInt()))
+        when(benchmarkExecutionDriver.execute(any(Benchmark.class), anyInt(), anyInt(), any()))
                 .thenReturn(successfulBenchmarkExecution());
         when(benchmarkProperties.getTimeLimit())
                 .thenReturn(Optional.empty());
@@ -117,7 +117,7 @@ public class ExecutionDriverTest
 
         driver.execute();
 
-        verify(benchmarkExecutionDriver).execute(any(Benchmark.class), anyInt(), anyInt());
+        verify(benchmarkExecutionDriver).execute(any(Benchmark.class), anyInt(), anyInt(), any());
         verifyNoMoreInteractions(benchmarkExecutionDriver);
     }
 

--- a/benchto-driver/src/test/java/io/prestodb/benchto/driver/utils/PermutationUtilsTest.java
+++ b/benchto-driver/src/test/java/io/prestodb/benchto/driver/utils/PermutationUtilsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestodb.benchto.driver.utils;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PermutationUtilsTest
+{
+    @Test
+    public void preparePermutation()
+    {
+        int[] permutation1 = PermutationUtils.preparePermutation(10, 1);
+
+        int[] permutation2 = PermutationUtils.preparePermutation(10, 2);
+        int[] permutation3 = PermutationUtils.preparePermutation(10, 2);
+        int[] sorted = IntStream.range(0, 10).toArray();
+        assertThat(permutation1).isNotEqualTo(permutation2);
+        assertThat(permutation1).isNotEqualTo(sorted);
+        assertThat(permutation2).isNotEqualTo(sorted);
+        assertThat(permutation2).isEqualTo(permutation3);
+        Arrays.sort(permutation1);
+        Arrays.sort(permutation2);
+        assertThat(permutation1).isEqualTo(sorted);
+        assertThat(permutation2).isEqualTo(sorted);
+    }
+}


### PR DESCRIPTION
As per TPC-H specification, we have to run power test and throughput test. currently benchto doesn't support throughput test and this PR is for to add that support into benchto.

Original PR: https://github.com/trinodb/benchto/pull/26
Cherry-pick of https://github.com/trinodb/benchto/commit/a26b7f86dc7e2b015aa1a1ec0dc599a638e2cd10

Co-authored-by: Paweł Pałucha, Karol Sobczak